### PR TITLE
Module code is strict by default (Traceur enforces this in compiled output code)

### DIFF
--- a/scripts/generators.js
+++ b/scripts/generators.js
@@ -1,4 +1,3 @@
-'use strict';
 /*jshint esnext: true */
 
 // This module defines several useful generators,

--- a/scripts/todo.js
+++ b/scripts/todo.js
@@ -1,4 +1,3 @@
-'use strict';
 /*jshint esnext: true */
 
 class Todo {

--- a/scripts/todolist.js
+++ b/scripts/todolist.js
@@ -1,4 +1,3 @@
-'use strict';
 /*jshint esnext: true */
 
 import Todo from './todo';


### PR DESCRIPTION
To support module "strict by default", all modules compiled by Traceur include the `use strict` pragma: 

``` js
System.register("../scripts/generators", [], function() {
  "use strict"; <--- always included :)
  var __moduleName = "../scripts/generators";
  ...

});
```

(also: Awesome article!)

Signed-off-by: Rick Waldron waldron.rick@gmail.com
